### PR TITLE
Pass allowEmpty flag to array-component gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,24 +4,24 @@ const uglify = require('gulp-uglify');
 
 gulp.task('concat-component-versions', () => {
   return gulp.src('./site/imported_json/component_versions/*.json')
-    .pipe(concat('componentVersionPartial.txt', {newLine: ','}))
+    .pipe(concat('componentVersionPartial.txt', { newLine: ',' }))
     .pipe(gulp.dest('./site/array'));
 });
 
 gulp.task('concat-components', () => {
   return gulp.src('./site/imported_json/components/*.json')
-    .pipe(concat('componentPartial.txt', {newLine: ','}))
+    .pipe(concat('componentPartial.txt', { newLine: ',' }))
     .pipe(gulp.dest('./site/array'));
 });
 
 gulp.task('array-component-versions', () => {
-  return gulp.src(['./site/array/start.txt', './site/array/componentVersionPartial.txt', './site/array/end.txt'])
+  return gulp.src(['./site/array/start.txt', './site/array/componentVersionPartial.txt', './site/array/end.txt'], { allowEmpty: true })
     .pipe(concat('component-versions.json'))
     .pipe(gulp.dest('./site/_data'));
 });
 
 gulp.task('array-components', () => {
-  return gulp.src(['./site/array/start.txt', './site/array/componentPartial.txt', './site/array/end.txt'])
+  return gulp.src(['./site/array/start.txt', './site/array/componentPartial.txt', './site/array/end.txt'], { allowEmpty: true })
     .pipe(concat('components.json'))
     .pipe(gulp.dest('./site/_data'));
 });


### PR DESCRIPTION
## Summary

- adds `allowEmpty` flag to array-component-versions and array-components gulp tasks (closes #14)
- has only been tested locally

## Testing

0. Follow local setup instructions in readme.
1. `npm run build` should complete with 11ty copying files to their intended location.

Should also be tested in staging environment.