### PR TITLE
Update starter code with 'module' attribute, fix action link in footer, fix broken team link

### DIFF
--- a/screenshot/index.html
+++ b/screenshot/index.html
@@ -60,7 +60,7 @@
             <nav slot="links" aria-label="Utility">
                 <ul>
                     <li><a href="https://builder.toolkit.illinois.edu">Old Builder</a></li>
-                    <li><a href="https://webtheme.illinois.edu/about/web-components/">About Our Team</a></li>
+                    <li><a href="https://wigg.illinois.edu/membership/web-components/">About Our Team</a></li>
                 </ul>
             </nav>
         </ilw-header>

--- a/site/_includes/footer.liquid
+++ b/site/_includes/footer.liquid
@@ -1,5 +1,7 @@
 <ilw-footer slot="footer">
   <a slot="primary-unit" href="https://webtheme.illinois.edu/about/">Web Implementation Guidelines Group</a>
   <a slot="site-name" href="/index.html">Component Builder Information (v3+)</a>
-  <a class="ilw-button" slot="actions" href="https://github.com/web-illinois/toolkit-builder-3/issues">Create an issue with the new toolkit builder</a>
+  <div slot="actions">
+    <a href="https://github.com/web-illinois/toolkit-builder-3/issues">Create an issue with the new toolkit builder</a>
+  </div>
 </ilw-footer>

--- a/site/_includes/header.liquid
+++ b/site/_includes/header.liquid
@@ -4,7 +4,7 @@
     <nav slot="links" aria-label="Utility">
     <ul>
       <li><a href="https://builder.toolkit.illinois.edu">Old Builder</a></li>
-      <li><a href="https://webtheme.illinois.edu/about/web-components/">About Our Team</a></li>
+      <li><a href="https://wigg.illinois.edu/membership/web-components/">About Our Team</a></li>
     </ul>
   </nav>
   <ilw-header-menu slot="navigation">

--- a/site/notes/header.md
+++ b/site/notes/header.md
@@ -30,7 +30,7 @@ If you are incorporating the header into the ilw-page component, then make sure 
   <nav slot="links" aria-label="Utility">
     <ul>
       <li><a href="https://builder.toolkit.illinois.edu">Old Builder</a></li>
-      <li><a href="https://webtheme.illinois.edu/about/web-components/">About Our Team</a></li>
+      <li><a href="https://wigg.illinois.edu/membership/web-components/">About Our Team</a></li>
     </ul>
   </nav>
   <form slot="search" method="get" action="/search.php" role="search">

--- a/site/pages/generic_html.md
+++ b/site/pages/generic_html.md
@@ -34,7 +34,7 @@ If you need a generic HTML template, feel free to use this:
         <link rel="dns-prefetch" href="//cdn.toolkit.illinois.edu"> 
         <link rel="dns-prefetch" href="//cdn.disability.illinois.edu"> 
         <link rel="stylesheet" href="//cdn.toolkit.illinois.edu/3/toolkit.css">
-        <script src="//cdn.toolkit.illinois.edu/3/toolkit.js"></script>
+        <script type="module" src="//cdn.toolkit.illinois.edu/3/toolkit.js"></script>
         <script src="//cdn.disability.illinois.edu/skipto.min.js"></script>
         <script>var SkipToConfig = { 'settings': { 'skipTo': { colorTheme: 'illinois' } } };</script>
         <title> <!-- Add title here --> </title>


### PR DESCRIPTION
I've run into a couple folks having issues with the toolkit due to naming collisions with other JS running on their site. Using the `type="module"` attribute seems to fix things nicely. This PR updates one page on the site that didn't have that attribute as part of the recommended code. Fixed a couple of broken links I noticed as well. 